### PR TITLE
perf(images): decode images at display size to avoid OOM on low-memory devices

### DIFF
--- a/lib/features/overview/presentation/mobile_overview_follow_tab.dart
+++ b/lib/features/overview/presentation/mobile_overview_follow_tab.dart
@@ -26,7 +26,8 @@ class MobileOverviewFollowTab extends StatefulWidget {
 }
 
 class _MobileOverviewFollowTabState extends State<MobileOverviewFollowTab> {
-  static const int _detailConcurrentLimit = 3;
+  static const int _detailConcurrentLimit = 1;
+  static const int _detailStillImageLimit = 8;
 
   late final PagedMovieSummaryController _moviesController;
   late final MovieCollectionTypeChangeNotifier _collectionChangeNotifier;
@@ -116,6 +117,7 @@ class _MobileOverviewFollowTabState extends State<MobileOverviewFollowTab> {
       setState(() {
         _movieDetailStates[movieNumber] = _FollowMovieDetailState.success(
           detail: detail,
+          stillImageLimit: _detailStillImageLimit,
         );
       });
     } catch (_) {
@@ -289,11 +291,14 @@ class _FollowMovieDetailState {
         stillImageUrls: const <String>[],
       );
 
-  factory _FollowMovieDetailState.success({required MovieDetailDto detail}) {
+  factory _FollowMovieDetailState.success({
+    required MovieDetailDto detail,
+    required int stillImageLimit,
+  }) {
     final stillImageUrls = detail.plotImages
         .map((image) => image.bestAvailableUrl.trim())
         .where((url) => url.isNotEmpty)
-        .take(24)
+        .take(stillImageLimit)
         .toList(growable: false);
     final summary =
         detail.summary.trim().isEmpty ? detail.title : detail.summary;

--- a/lib/widgets/media/masked_image.dart
+++ b/lib/widgets/media/masked_image.dart
@@ -22,6 +22,9 @@ class MaskedImage extends StatelessWidget {
              (visibleWidthFactor > 0 && visibleWidthFactor <= 1),
        );
 
+  static const double _decodeDevicePixelRatioCap = 2.0;
+  static const int _decodeSizeUpperBound = 1024;
+
   final String url;
   final BoxFit fit;
   final double? visibleWidthFactor;
@@ -40,39 +43,43 @@ class MaskedImage extends StatelessWidget {
       return const _MaskedImagePlaceholder(icon: Icons.image_outlined);
     }
 
-    final image = CachedNetworkImage(
-      imageUrl: resolvedUrl,
-      fit: fit,
-      memCacheWidth: memCacheWidth,
-      memCacheHeight: memCacheHeight,
-      fadeInDuration: const Duration(milliseconds: 250),
-      fadeOutDuration: const Duration(milliseconds: 150),
-      placeholder: (context, url) {
-        return const _MaskedImagePlaceholder(icon: Icons.image_outlined);
-      },
-      errorWidget: (context, url, error) {
-        return const _MaskedImagePlaceholder(icon: Icons.broken_image_outlined);
-      },
-    );
-
-    Widget imageContent = image;
-
-    if (AppImageConfig.enableBlur && AppImageConfig.blurSigma > 0) {
-      imageContent = ImageFiltered(
-        imageFilter: ImageFilter.blur(
-          sigmaX: AppImageConfig.blurSigma,
-          sigmaY: AppImageConfig.blurSigma,
-        ),
-        child: imageContent,
-      );
-    }
-
-    if (visibleWidthFactor == null) {
-      return imageContent;
-    }
-
     return LayoutBuilder(
       builder: (context, constraints) {
+        final decodeHint = _resolveDecodeHint(context, constraints);
+
+        final image = CachedNetworkImage(
+          imageUrl: resolvedUrl,
+          fit: fit,
+          memCacheWidth: memCacheWidth ?? decodeHint.width,
+          memCacheHeight: memCacheHeight ?? decodeHint.height,
+          fadeInDuration: const Duration(milliseconds: 250),
+          fadeOutDuration: const Duration(milliseconds: 150),
+          placeholder: (context, url) {
+            return const _MaskedImagePlaceholder(icon: Icons.image_outlined);
+          },
+          errorWidget: (context, url, error) {
+            return const _MaskedImagePlaceholder(
+              icon: Icons.broken_image_outlined,
+            );
+          },
+        );
+
+        Widget imageContent = image;
+
+        if (AppImageConfig.enableBlur && AppImageConfig.blurSigma > 0) {
+          imageContent = ImageFiltered(
+            imageFilter: ImageFilter.blur(
+              sigmaX: AppImageConfig.blurSigma,
+              sigmaY: AppImageConfig.blurSigma,
+            ),
+            child: imageContent,
+          );
+        }
+
+        if (visibleWidthFactor == null) {
+          return imageContent;
+        }
+
         if (!constraints.hasBoundedWidth || !constraints.maxWidth.isFinite) {
           return imageContent;
         }
@@ -99,6 +106,44 @@ class MaskedImage extends StatelessWidget {
         );
       },
     );
+  }
+
+  ({int? width, int? height}) _resolveDecodeHint(
+    BuildContext context,
+    BoxConstraints constraints,
+  ) {
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final effectiveDpr =
+        dpr.clamp(1.0, _decodeDevicePixelRatioCap) as double;
+
+    int? cacheWidth;
+    if (constraints.hasBoundedWidth &&
+        constraints.maxWidth.isFinite &&
+        constraints.maxWidth > 0) {
+      final factor = visibleWidthFactor;
+      final widthMultiplier =
+          (factor != null && factor > 0 && factor <= 1) ? 1 / factor : 1.0;
+      cacheWidth =
+          ((constraints.maxWidth * widthMultiplier * effectiveDpr).round())
+                  .clamp(1, _decodeSizeUpperBound)
+              as int;
+    }
+
+    int? cacheHeight;
+    if (constraints.hasBoundedHeight &&
+        constraints.maxHeight.isFinite &&
+        constraints.maxHeight > 0) {
+      cacheHeight =
+          ((constraints.maxHeight * effectiveDpr).round())
+                  .clamp(1, _decodeSizeUpperBound)
+              as int;
+    }
+
+    if (cacheWidth != null && cacheHeight != null) {
+      return (width: cacheWidth, height: null);
+    }
+
+    return (width: cacheWidth, height: cacheHeight);
   }
 }
 

--- a/lib/widgets/movie_detail/movie_plot_thumbnail.dart
+++ b/lib/widgets/movie_detail/movie_plot_thumbnail.dart
@@ -31,6 +31,9 @@ class MoviePlotThumbnail extends StatefulWidget {
 }
 
 class _MoviePlotThumbnailState extends State<MoviePlotThumbnail> {
+  static const double _decodeDevicePixelRatioCap = 2.0;
+  static const int _decodeSizeUpperBound = 1024;
+
   ImageStream? _imageStream;
   ImageStreamListener? _imageStreamListener;
   ImageProvider<Object>? _resolvedImageProvider;
@@ -46,7 +49,8 @@ class _MoviePlotThumbnailState extends State<MoviePlotThumbnail> {
   void didUpdateWidget(covariant MoviePlotThumbnail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.url != widget.url ||
-        oldWidget.imageProvider != widget.imageProvider) {
+        oldWidget.imageProvider != widget.imageProvider ||
+        oldWidget.maxHeight != widget.maxHeight) {
       _resolveImageProvider();
     }
   }
@@ -69,6 +73,18 @@ class _MoviePlotThumbnailState extends State<MoviePlotThumbnail> {
   }
 
   ImageProvider<Object>? _buildImageProvider() {
+    final base = _buildBaseImageProvider();
+    if (base == null) {
+      return null;
+    }
+    final decodeHeight = _resolveDecodeHeight();
+    if (decodeHeight == null) {
+      return base;
+    }
+    return ResizeImage(base, height: decodeHeight, allowUpscaling: false);
+  }
+
+  ImageProvider<Object>? _buildBaseImageProvider() {
     if (widget.imageProvider != null) {
       return widget.imageProvider;
     }
@@ -83,6 +99,18 @@ class _MoviePlotThumbnailState extends State<MoviePlotThumbnail> {
     }
 
     return CachedNetworkImageProvider(resolvedUrl);
+  }
+
+  int? _resolveDecodeHeight() {
+    if (!widget.maxHeight.isFinite || widget.maxHeight <= 0) {
+      return null;
+    }
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final effectiveDpr =
+        dpr.clamp(1.0, _decodeDevicePixelRatioCap) as double;
+    return ((widget.maxHeight * effectiveDpr).round())
+            .clamp(1, _decodeSizeUpperBound)
+        as int;
   }
 
   void _listenToImageStream(ImageProvider<Object>? provider) {


### PR DESCRIPTION
关注页面与缩略图页面在 iPad Air 3（3GB 内存）上因按原始分辨率解码大量
封面与剧照导致闪退。改为按视口尺寸（受 DPR 与 1024 像素上限约束）解码：

- MaskedImage 在未显式传入 memCacheWidth/Height 时，通过 LayoutBuilder
  自动推导解码尺寸；visibleWidthFactor 裁剪时按比例放大解码宽度。
- MoviePlotThumbnail 用 ResizeImage 以 maxHeight × DPR 解码，保持比例。
- 移动端「关注」标签页：并发拉取详情数 3→1，单卡片剧照数 24→8，以降低
  峰值内存与并发解码数。