### PR TITLE
feat(downloads): 磁力搜索结果显示并复制链接

### DIFF
--- a/lib/core/platform/clipboard_copy.dart
+++ b/lib/core/platform/clipboard_copy.dart
@@ -1,0 +1,2 @@
+export 'clipboard_copy_stub.dart'
+    if (dart.library.js_interop) 'clipboard_copy_web.dart';

--- a/lib/core/platform/clipboard_copy_stub.dart
+++ b/lib/core/platform/clipboard_copy_stub.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/services.dart';
+
+Future<bool> copyTextToClipboard(String text) async {
+  try {
+    await Clipboard.setData(ClipboardData(text: text));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/lib/core/platform/clipboard_copy_web.dart
+++ b/lib/core/platform/clipboard_copy_web.dart
@@ -1,0 +1,41 @@
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+Future<bool> copyTextToClipboard(String text) async {
+  if (web.window.isSecureContext) {
+    try {
+      await web.window.navigator.clipboard.writeText(text).toDart;
+      return true;
+    } catch (_) {
+      // Fall back for browsers that deny the Clipboard API.
+    }
+  }
+  return _copyTextWithLegacyApi(text);
+}
+
+bool _copyTextWithLegacyApi(String text) {
+  final textArea =
+      web.HTMLTextAreaElement()
+        ..value = text
+        ..readOnly = true
+        ..style.cssText =
+            'position:fixed;left:0;top:0;width:1px;height:1px;'
+            'opacity:0;pointer-events:none;';
+  final body = web.document.body;
+  if (body == null) {
+    return false;
+  }
+
+  body.append(textArea);
+  try {
+    textArea.focus();
+    textArea.select();
+    textArea.setSelectionRange(0, text.length);
+    return web.document.execCommand('copy');
+  } catch (_) {
+    return false;
+  } finally {
+    textArea.remove();
+  }
+}

--- a/lib/features/movies/presentation/widgets/detail/movie_detail_inspector_panel.dart
+++ b/lib/features/movies/presentation/widgets/detail/movie_detail_inspector_panel.dart
@@ -9,6 +9,7 @@ import 'package:sakuramedia/core/format/file_size.dart';
 import 'package:sakuramedia/core/media/image_save_service.dart';
 import 'package:sakuramedia/core/network/api_client.dart';
 import 'package:sakuramedia/core/network/api_error_message.dart';
+import 'package:sakuramedia/core/platform/clipboard_copy.dart';
 import 'package:sakuramedia/features/clips/presentation/widgets/create_clip_dialog.dart';
 import 'package:sakuramedia/features/configuration/data/dto/download_client_dto.dart';
 import 'package:sakuramedia/features/downloads/data/download_candidate_dto.dart';
@@ -966,6 +967,7 @@ class _MovieDetailMagnetTab extends StatelessWidget {
           key: Key('movie-detail-magnet-candidate-$index'),
           candidate: item,
           isSubmitting: controller.submittingCandidateKey == item.submitKey,
+          copyButtonKey: Key('movie-detail-magnet-copy-$index'),
           submitButtonKey: Key('movie-detail-magnet-submit-$index'),
           onSubmit: item.hasDownloadSource
               ? (clientId) async {
@@ -1006,12 +1008,14 @@ class _MovieDetailMagnetCandidateCard extends StatefulWidget {
     super.key,
     required this.candidate,
     required this.isSubmitting,
+    required this.copyButtonKey,
     required this.submitButtonKey,
     required this.onSubmit,
   });
 
   final DownloadCandidateDto candidate;
   final bool isSubmitting;
+  final Key copyButtonKey;
   final Key submitButtonKey;
   final ValueChanged<int>? onSubmit;
 
@@ -1052,6 +1056,8 @@ class _MovieDetailMagnetCandidateCardState
 
   @override
   Widget build(BuildContext context) {
+    final magnetUrl = candidate.magnetUrl.trim();
+
     return Container(
       width: double.infinity,
       padding: EdgeInsets.all(context.appSpacing.lg),
@@ -1089,6 +1095,66 @@ class _MovieDetailMagnetCandidateCardState
               ),
             ],
           ),
+          if (magnetUrl.isNotEmpty) ...[
+            SizedBox(height: context.appSpacing.md),
+            Container(
+              key: const Key('movie-detail-magnet-link'),
+              width: double.infinity,
+              padding: EdgeInsets.all(context.appSpacing.sm),
+              decoration: BoxDecoration(
+                color: context.appColors.surfaceMuted,
+                borderRadius: context.appRadius.mdBorder,
+                border: Border.all(color: context.appColors.borderSubtle),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          '磁力链接',
+                          style: resolveAppTextStyle(
+                            context,
+                            size: AppTextSize.s12,
+                            weight: AppTextWeight.medium,
+                            tone: AppTextTone.secondary,
+                          ),
+                        ),
+                      ),
+                      AppButton(
+                        key: widget.copyButtonKey,
+                        size: AppButtonSize.xxSmall,
+                        label: '复制',
+                        icon: const Icon(Icons.copy_rounded),
+                        variant: AppButtonVariant.secondary,
+                        onPressed: () async {
+                          final copied = await copyTextToClipboard(magnetUrl);
+                          if (context.mounted) {
+                            showToast(
+                              copied ? '磁力链接已复制' : '复制失败，请手动选择链接',
+                            );
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: context.appSpacing.xs),
+                  SelectableText(
+                    magnetUrl,
+                    key: const Key('movie-detail-magnet-link-text'),
+                    maxLines: 3,
+                    style: resolveAppTextStyle(
+                      context,
+                      size: AppTextSize.s10,
+                      weight: AppTextWeight.regular,
+                      tone: AppTextTone.secondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
           SizedBox(height: context.appSpacing.md),
           Row(
             children: [

--- a/test/features/movies/presentation/widgets/detail/movie_detail_inspector_panel_test.dart
+++ b/test/features/movies/presentation/widgets/detail/movie_detail_inspector_panel_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oktoast/oktoast.dart';
 import 'package:provider/provider.dart';
@@ -399,6 +400,78 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(submittedClientId, 3);
+    await tester.pump(const Duration(seconds: 3));
+  });
+
+  testWidgets('magnet candidate shows and copies its full magnet link', (
+    WidgetTester tester,
+  ) async {
+    const magnetUrl = 'magnet:?xt=urn:btih:abcdef&dn=ABC-001';
+    Object? clipboardArguments;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardArguments = call.arguments;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    await _pumpInspectorPanel(
+      tester,
+      panelHeight: 640,
+      fetchMovieReviews: ({
+        required String movieNumber,
+        required int page,
+        required int pageSize,
+        required MovieReviewSort sort,
+      }) async =>
+          const <MovieReviewDto>[],
+      searchCandidates: ({
+        required String movieNumber,
+        String? indexerKind,
+      }) async =>
+          const <DownloadCandidateDto>[
+        DownloadCandidateDto(
+          source: 'jackett',
+          indexerName: 'dmhy',
+          indexerKind: 'bt',
+          resolvedClientId: 2,
+          resolvedClientName: 'qb-main',
+          movieNumber: 'ABC-001',
+          title: 'ABC-001 中文字幕',
+          sizeBytes: 1024,
+          seeders: 8,
+          magnetUrl: magnetUrl,
+          torrentUrl: '',
+          tags: <String>[],
+        ),
+      ],
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('磁力搜索'));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const Key('movie-detail-magnet-search-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('磁力链接'), findsOneWidget);
+    expect(find.text(magnetUrl), findsOneWidget);
+
+    final copyButton = find.byKey(const Key('movie-detail-magnet-copy-0'));
+    await tester.ensureVisible(copyButton);
+    await tester.tap(copyButton);
+    await tester.pump();
+
+    expect(clipboardArguments, <String, dynamic>{'text': magnetUrl});
+    expect(find.text('磁力链接已复制'), findsOneWidget);
     await tester.pump(const Duration(seconds: 3));
   });
 


### PR DESCRIPTION
## 修改

- 在影片详情的磁力搜索结果中显示完整磁力链接。
- 为每条结果增加复制按钮，同时保留可手动选择的文本。
- Web 端优先使用 Clipboard API；在 HTTP 局域网等非安全上下文中回退到浏览器兼容复制方式。
- 非 Web 平台继续使用 Flutter 系统剪贴板。

## 原因

搜索结果原先只能直接提交下载，用户无法查看或复制实际磁力链接。浏览器的 Clipboard API 通常要求 HTTPS，导致 HTTP 私有部署无法可靠复制。

## 影响

不改变搜索和提交下载逻辑，只增加链接展示和复制能力。复制失败时会提示用户手动选择链接。

## 验证

- `flutter test test/features/movies/presentation/widgets/detail/movie_detail_inspector_panel_test.dart`
- `dart analyze`（本 PR 涉及的 5 个 Dart 文件）
- `flutter build web --release --no-pub`
