### PR TITLE
feat: inline review/magnet/thumbnail sections in movie detail page

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -1,0 +1,23 @@
+name: Build Web
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [inline-detail-sections]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.29.3
+      - run: flutter pub get
+      - run: flutter build web --release --no-web-resources-cdn
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: build/web/
+          retention-days: 1

--- a/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
+++ b/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
@@ -1,18 +1,27 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:sakuramedia/core/format/file_size.dart';
+import 'package:sakuramedia/core/platform/clipboard_copy.dart';
 import 'package:sakuramedia/features/clips/data/dto/media_clip_dto.dart';
 import 'package:sakuramedia/features/media/data/media_play_url_dto.dart';
 import 'package:sakuramedia/features/movies/data/dto/detail/movie_detail_dto.dart';
 import 'package:sakuramedia/features/media/data/media_storage_descriptor.dart';
+import 'package:sakuramedia/features/movies/data/dto/detail/movie_review_dto.dart';
 import 'package:sakuramedia/features/movies/data/dto/listing/movie_list_item_dto.dart';
 import 'package:sakuramedia/features/movies/presentation/actions/movie_collection_feature_actions.dart';
+import 'package:sakuramedia/features/movies/presentation/providers/movie_detail_magnet_provider.dart';
+import 'package:sakuramedia/features/movies/presentation/providers/movie_detail_review_provider.dart';
+import 'package:sakuramedia/features/movies/presentation/providers/movie_detail_thumbnail_provider.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_playback_options.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_playback_options_bar.dart';
+import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_detail_inspector_panel.dart';
 import 'package:sakuramedia/theme.dart';
 import 'package:sakuramedia/widgets/base/actions/app_icon_button.dart';
+import 'package:sakuramedia/widgets/base/actions/app_text_button.dart';
 import 'package:sakuramedia/widgets/base/feedback/app_empty_state.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_actor_wrap.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_detail_bottom_info_bar.dart';
@@ -26,6 +35,7 @@ import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_me
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_plot_gallery.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_similar_movie_strip.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_tag_wrap.dart';
+import 'package:sakuramedia/widgets/domain/media/movie_media_thumbnail_grid.dart';
 
 typedef MovieDetailScrollViewBuilder =
     Widget Function(
@@ -392,6 +402,30 @@ class MovieDetailPageContent extends StatelessWidget {
                 ),
           ),
         ),
+
+        // ── Inline: 评论 ──────────────────────────────────────────────
+        MovieDetailSection(
+          title: '评论',
+          titleKey: const Key('movie-detail-inline-review-title'),
+          child: _InlineReviewSection(movieNumber: movie.movieNumber),
+        ),
+
+        // ── Inline: 磁力搜索 ─────────────────────────────────────────
+        MovieDetailSection(
+          title: '磁力搜索',
+          titleKey: const Key('movie-detail-inline-magnet-title'),
+          child: _InlineMagnetSection(movieNumber: movie.movieNumber),
+        ),
+
+        // ── Inline: 缩略图 ─────────────────────────────────────────────
+        MovieDetailSection(
+          title: '缩略图',
+          titleKey: const Key('movie-detail-inline-thumbnail-title'),
+          child: _InlineThumbnailSection(
+            movieNumber: movie.movieNumber,
+            mediaId: selectedMediaId,
+          ),
+        ),
       ],
     );
   }
@@ -594,6 +628,513 @@ class _SkeletonBlock extends StatelessWidget {
         color: context.appColors.surfaceMuted,
         borderRadius: context.appRadius.mdBorder,
       ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inline sections: 评论 / 磁力搜索 / 缩略图
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _InlineReviewSection extends ConsumerStatefulWidget {
+  const _InlineReviewSection({required this.movieNumber});
+
+  final String movieNumber;
+
+  @override
+  ConsumerState<_InlineReviewSection> createState() =>
+      _InlineReviewSectionState();
+}
+
+class _InlineReviewSectionState extends ConsumerState<_InlineReviewSection> {
+  MovieDetailReview get _controller =>
+      ref.read(movieDetailReviewProvider(widget.movieNumber).notifier);
+  MovieDetailReviewState get _state =>
+      ref.read(movieDetailReviewProvider(widget.movieNumber));
+
+  late final ScrollController _scrollController;
+  int _lastAutoLoadTriggerItemCount = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController()..addListener(_handleScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_controller.loadInitial());
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _handleScroll() {
+    if (!_scrollController.hasClients) return;
+    if (_scrollController.position.extentAfter > 200) {
+      _lastAutoLoadTriggerItemCount = -1;
+      return;
+    }
+    if (_state.items.length == _lastAutoLoadTriggerItemCount) return;
+    _lastAutoLoadTriggerItemCount = _state.items.length;
+    _controller.loadMore();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(movieDetailReviewProvider(widget.movieNumber));
+
+    if (state.isInitialLoading && state.items.isEmpty) {
+      return _buildSkeleton();
+    }
+
+    if (state.initialErrorMessage != null && state.items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(state.initialErrorMessage!,
+                style: resolveAppTextStyle(context, size: AppTextSize.s14,
+                    tone: AppTextTone.secondary)),
+            SizedBox(height: context.appSpacing.md),
+            TextButton(
+                onPressed: _controller.loadInitial, child: const Text('重试')),
+          ],
+        ),
+      );
+    }
+
+    if (state.items.isEmpty) {
+      return const Center(child: AppEmptyState(message: '暂无评论'));
+    }
+
+    return SizedBox(
+      height: 220,
+      child: ListView.separated(
+        controller: _scrollController,
+        key: const Key('inline-review-list'),
+        itemCount: state.items.length + 1,
+        separatorBuilder: (_, __) =>
+            SizedBox(height: context.appSpacing.sm),
+        itemBuilder: (context, index) {
+          if (index < state.items.length) {
+            return _InlineReviewCard(review: state.items[index]);
+          }
+          if (state.isLoadingMore) {
+            return const Center(
+                child: Padding(
+              padding: EdgeInsets.all(8),
+              child: CupertinoActivityIndicator(),
+            ));
+          }
+          if (state.loadMoreErrorMessage != null) {
+            return Center(
+                child: TextButton(
+                    onPressed: _controller.loadMore,
+                    child: Text(state.loadMoreErrorMessage!)));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+
+  Widget _buildSkeleton() {
+    return SizedBox(
+      height: 220,
+      child: ListView.separated(
+        itemCount: 3,
+        separatorBuilder: (_, __) =>
+            SizedBox(height: context.appSpacing.sm),
+        itemBuilder: (_, __) => Container(
+          height: 64,
+          decoration: BoxDecoration(
+            color: context.appColors.surfaceMuted,
+            borderRadius: context.appRadius.mdBorder,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineReviewCard extends StatelessWidget {
+  const _InlineReviewCard({required this.review});
+  final MovieReviewDto review;
+
+  @override
+  Widget build(BuildContext context) {
+    final reviewDate = review.createdAt == null
+        ? '--/--/--'
+        : DateFormat('yy/MM/dd').format(review.createdAt!.toLocal());
+    return Container(
+      padding: EdgeInsets.all(context.appSpacing.sm),
+      decoration: BoxDecoration(
+        color: context.appColors.surfaceMuted,
+        borderRadius: context.appRadius.smBorder,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Avatar placeholder
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: context.appColors.surfaceCard,
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: Text(
+                (review.username.trim().isEmpty ? '匿' : review.username)
+                    .substring(0, 1)
+                    .toUpperCase(),
+                style: resolveAppTextStyle(context, size: AppTextSize.s12,
+                    weight: AppTextWeight.medium),
+              ),
+            ),
+          ),
+          SizedBox(width: context.appSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      review.username.trim().isEmpty
+                          ? '匿名用户'
+                          : review.username,
+                      style: resolveAppTextStyle(context, size: AppTextSize.s12,
+                          weight: AppTextWeight.medium),
+                    ),
+                    SizedBox(width: context.appSpacing.xs),
+                    Icon(Icons.star_rounded,
+                        size: 12,
+                        color: context.appColors.movieDetailScoreIcon),
+                    Text('${review.score}',
+                        style: resolveAppTextStyle(context,
+                            size: AppTextSize.s10,
+                            tone: AppTextTone.secondary)),
+                    const Spacer(),
+                    Text(reviewDate,
+                        style: resolveAppTextStyle(context,
+                            size: AppTextSize.s10,
+                            tone: AppTextTone.muted)),
+                  ],
+                ),
+                SizedBox(height: context.appSpacing.xs),
+                Text(
+                  review.content.trim().isEmpty
+                      ? '暂无评论内容'
+                      : review.content,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: resolveAppTextStyle(context, size: AppTextSize.s12,
+                      tone: AppTextTone.secondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InlineMagnetSection extends ConsumerStatefulWidget {
+  const _InlineMagnetSection({required this.movieNumber});
+
+  final String movieNumber;
+
+  @override
+  ConsumerState<_InlineMagnetSection> createState() =>
+      _InlineMagnetSectionState();
+}
+
+class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
+  MovieDetailMagnet get _controller =>
+      ref.read(movieDetailMagnetProvider(widget.movieNumber).notifier);
+  MovieDetailMagnetState get _state =>
+      ref.read(movieDetailMagnetProvider(widget.movieNumber));
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_controller.search());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(movieDetailMagnetProvider(widget.movieNumber));
+
+    if (state.isLoading && state.items.isEmpty) {
+      return _buildSkeleton();
+    }
+
+    if (state.errorMessage != null && state.items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(state.errorMessage!,
+                style: resolveAppTextStyle(context, size: AppTextSize.s14,
+                    tone: AppTextTone.secondary)),
+            SizedBox(height: context.appSpacing.md),
+            TextButton(
+                onPressed: () => _controller.search(),
+                child: const Text('重试')),
+          ],
+        ),
+      );
+    }
+
+    if (state.items.isEmpty && state.hasSearched) {
+      return const Center(child: AppEmptyState(message: '暂无磁力资源'));
+    }
+
+    return Column(
+      children: [
+        // Sort bar
+        Wrap(
+          spacing: context.appSpacing.xs,
+          children: [
+            for (final field in MovieDetailMagnetSortField.values)
+              AppTextButton(
+                key: Key('inline-magnet-sort-${field.name}'),
+                label: field.label,
+                size: AppTextButtonSize.xSmall,
+                isSelected: state.selectedSortField == field,
+                onPressed: () => _controller.setSortField(field),
+              ),
+            AppTextButton(
+              key: const Key('inline-magnet-dir'),
+              label: state.selectedSortDirection ==
+                      MovieDetailMagnetSortDirection.desc
+                  ? '↓'
+                  : '↑',
+              size: AppTextButtonSize.xSmall,
+              isSelected: false,
+              onPressed: () => _controller.toggleSortDirection(),
+            ),
+          ],
+        ),
+        SizedBox(height: context.appSpacing.sm),
+        if (state.items.isEmpty)
+          const Center(
+              child: Padding(
+            padding: EdgeInsets.all(16),
+            child: CupertinoActivityIndicator(),
+          ))
+        else
+          SizedBox(
+            height: 180,
+            child: ListView.separated(
+              key: const Key('inline-magnet-list'),
+              itemCount: state.sortedItems.length,
+              separatorBuilder: (_, __) =>
+                  SizedBox(height: context.appSpacing.sm),
+              itemBuilder: (context, index) {
+                final candidate = state.sortedItems[index];
+                return _InlineMagnetCard(candidate: candidate);
+              },
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildSkeleton() {
+    return SizedBox(
+      height: 180,
+      child: ListView.separated(
+        itemCount: 3,
+        separatorBuilder: (_, __) =>
+            SizedBox(height: context.appSpacing.sm),
+        itemBuilder: (_, __) => Container(
+          height: 52,
+          decoration: BoxDecoration(
+            color: context.appColors.surfaceMuted,
+            borderRadius: context.appRadius.mdBorder,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineMagnetCard extends StatelessWidget {
+  const _InlineMagnetCard({required this.candidate});
+  final dynamic candidate; // DownloadCandidateDto
+
+  @override
+  Widget build(BuildContext context) {
+    final magnetUrl = candidate.magnetUrl ?? '';
+    return Container(
+      padding: EdgeInsets.all(context.appSpacing.sm),
+      decoration: BoxDecoration(
+        color: context.appColors.surfaceMuted,
+        borderRadius: context.appRadius.smBorder,
+        border: Border.all(color: context.appColors.borderSubtle),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  candidate.title ?? '',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: resolveAppTextStyle(context, size: AppTextSize.s12,
+                      weight: AppTextWeight.medium),
+                ),
+                SizedBox(height: context.appSpacing.xs),
+                Wrap(
+                  spacing: context.appSpacing.sm,
+                  children: [
+                    Text(
+                      '做种: ${candidate.seeders}',
+                      style: resolveAppTextStyle(context,
+                          size: AppTextSize.s10,
+                          tone: AppTextTone.muted),
+                    ),
+                    Text(
+                      formatFileSize(candidate.sizeBytes),
+                      style: resolveAppTextStyle(context,
+                          size: AppTextSize.s10,
+                          tone: AppTextTone.muted),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          if (magnetUrl.isNotEmpty)
+            AppIconButton(
+              key: const Key('inline-magnet-copy'),
+              tooltip: '复制磁力链接',
+              size: AppIconButtonSize.mini,
+              onPressed: () async {
+                final copied = await copyTextToClipboard(magnetUrl);
+                if (context.mounted) {
+                  showToast(copied ? '磁力链接已复制' : '复制失败');
+                }
+              },
+              icon: const Icon(Icons.copy_rounded, size: 16),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InlineThumbnailSection extends ConsumerWidget {
+  const _InlineThumbnailSection({
+    required this.movieNumber,
+    required this.mediaId,
+  });
+
+  final String movieNumber;
+  final int? mediaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(movieDetailThumbnailProvider(mediaId: mediaId));
+    final controller =
+        ref.read(movieDetailThumbnailProvider(mediaId: mediaId).notifier);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Toolbar
+        Wrap(
+          spacing: 12,
+          runSpacing: context.appSpacing.xs,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            for (final seconds in [10, 20, 30, 60])
+              AppTextButton(
+                key: Key('inline-thumb-interval-$seconds'),
+                label: '$seconds秒',
+                size: AppTextButtonSize.xSmall,
+                isSelected: state.selectedIntervalSeconds == seconds,
+                onPressed: () => controller.setIntervalSeconds(seconds),
+              ),
+            for (final cols in [2, 3, 4])
+              AppTextButton(
+                key: Key('inline-thumb-cols-$cols'),
+                label: '$cols列',
+                size: AppTextButtonSize.xSmall,
+                isSelected: (state.columns ?? 3) == cols,
+                onPressed: () => controller.setColumns(cols),
+              ),
+          ],
+        ),
+        SizedBox(height: context.appSpacing.md),
+        if (state.isLoading && state.thumbnails.isEmpty)
+          Container(
+            height: 200,
+            decoration: BoxDecoration(
+              color: context.appColors.surfaceMuted,
+              borderRadius: context.appRadius.mdBorder,
+            ),
+            child: const Center(child: CupertinoActivityIndicator()),
+          )
+        else if (state.errorMessage != null && state.thumbnails.isEmpty)
+          Center(
+            child: TextButton(
+                onPressed: controller.retry, child: const Text('重试')),
+          )
+        else if (state.thumbnails.isEmpty)
+          const Center(child: AppEmptyState(message: '暂无缩略图'))
+        else
+          SizedBox(
+            height: 200,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final columns = state.columns ?? 3;
+                final spacing = context.appSpacing.xs;
+                final itemWidth =
+                    (constraints.maxWidth - spacing * (columns - 1)) /
+                        columns;
+                final itemHeight = itemWidth * 0.6;
+
+                return GridView.builder(
+                  key: const Key('inline-thumbnail-grid'),
+                  scrollDirection: Axis.horizontal,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    mainAxisSpacing: spacing,
+                    crossAxisSpacing: spacing,
+                    childAspectRatio: itemWidth / itemHeight,
+                  ),
+                  itemCount: state.thumbnails.length,
+                  itemBuilder: (context, index) {
+                    final thumb = state.thumbnails[index];
+                    return ClipRRect(
+                      borderRadius: context.appRadius.smBorder,
+                      child: thumb.image.resolvedUrl.isEmpty
+                          ? Container(color: context.appColors.surfaceMuted)
+                          : Image.network(
+                              thumb.image.resolvedUrl,
+                              fit: BoxFit.cover,
+                              errorBuilder: (_, __, ___) => Container(
+                                  color: context.appColors.surfaceMuted),
+                            ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
+++ b/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
@@ -3,7 +3,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:oktoast/oktoast.dart';
 import 'package:sakuramedia/core/format/file_size.dart';
 import 'package:sakuramedia/core/platform/clipboard_copy.dart';
 import 'package:sakuramedia/features/clips/data/dto/media_clip_dto.dart';
@@ -874,7 +876,7 @@ class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
     final state = ref.watch(movieDetailMagnetProvider(widget.movieNumber));
 
     if (state.isLoading && state.items.isEmpty) {
-      return _buildSkeleton();
+      return _buildSkeleton(context);
     }
 
     if (state.errorMessage != null && state.items.isEmpty) {
@@ -949,18 +951,18 @@ class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
     );
   }
 
-  Widget _buildSkeleton() {
+  Widget _buildSkeleton(BuildContext ctx) {
     return SizedBox(
       height: 180,
       child: ListView.separated(
         itemCount: 3,
         separatorBuilder: (_, __) =>
-            SizedBox(height: context.appSpacing.sm),
+            SizedBox(height: ctx.appSpacing.sm),
         itemBuilder: (_, __) => Container(
           height: 52,
           decoration: BoxDecoration(
-            color: context.appColors.surfaceMuted,
-            borderRadius: context.appRadius.mdBorder,
+            color: ctx.appColors.surfaceMuted,
+            borderRadius: ctx.appRadius.mdBorder,
           ),
         ),
       ),

--- a/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
+++ b/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
@@ -1032,12 +1032,39 @@ class _InlineMagnetCardState extends ConsumerState<_InlineMagnetCard> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      widget.candidate.title ?? '',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: resolveAppTextStyle(context, size: AppTextSize.s12,
-                          weight: AppTextWeight.medium),
+                    Row(
+                      children: [
+                        if (widget.candidate.indexerName.isNotEmpty)
+                          Container(
+                            margin: EdgeInsets.only(right: context.appSpacing.xs),
+                            padding: EdgeInsets.symmetric(
+                              horizontal: context.appSpacing.xs,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              color: context.appColors.movieCardPlayableBadgeBackground
+                                  .withValues(alpha: 0.2),
+                              borderRadius: context.appRadius.xsBorder,
+                            ),
+                            child: Text(
+                              widget.candidate.indexerName,
+                              style: resolveAppTextStyle(context,
+                                  size: AppTextSize.s10,
+                                  weight: AppTextWeight.medium,
+                                  tone: AppTextTone.primary),
+                            ),
+                          ),
+                        Expanded(
+                          child: Text(
+                            widget.candidate.title ?? '',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: resolveAppTextStyle(context,
+                                size: AppTextSize.s12,
+                                weight: AppTextWeight.medium),
+                          ),
+                        ),
+                      ],
                     ),
                     SizedBox(height: context.appSpacing.xs),
                     Wrap(

--- a/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
+++ b/lib/features/movies/presentation/pages/shared/movie_detail_page_content.dart
@@ -16,6 +16,9 @@ import 'package:sakuramedia/features/movies/data/dto/detail/movie_review_dto.dar
 import 'package:sakuramedia/features/movies/data/dto/listing/movie_list_item_dto.dart';
 import 'package:sakuramedia/features/movies/presentation/actions/movie_collection_feature_actions.dart';
 import 'package:sakuramedia/features/movies/presentation/providers/movie_detail_magnet_provider.dart';
+import 'package:sakuramedia/features/downloads/data/download_candidate_dto.dart';
+import 'package:sakuramedia/widgets/base/actions/app_button.dart';
+import 'package:sakuramedia/widgets/base/forms/app_select_field.dart';
 import 'package:sakuramedia/features/movies/presentation/providers/movie_detail_review_provider.dart';
 import 'package:sakuramedia/features/movies/presentation/providers/movie_detail_thumbnail_provider.dart';
 import 'package:sakuramedia/features/movies/presentation/widgets/detail/movie_playback_options.dart';
@@ -713,7 +716,7 @@ class _InlineReviewSectionState extends ConsumerState<_InlineReviewSection> {
     }
 
     return SizedBox(
-      height: 220,
+      height: 320,
       child: ListView.separated(
         controller: _scrollController,
         key: const Key('inline-review-list'),
@@ -745,7 +748,7 @@ class _InlineReviewSectionState extends ConsumerState<_InlineReviewSection> {
 
   Widget _buildSkeleton() {
     return SizedBox(
-      height: 220,
+      height: 320,
       child: ListView.separated(
         itemCount: 3,
         separatorBuilder: (_, __) =>
@@ -935,7 +938,7 @@ class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
           ))
         else
           SizedBox(
-            height: 180,
+            height: 280,
             child: ListView.separated(
               key: const Key('inline-magnet-list'),
               itemCount: state.sortedItems.length,
@@ -943,7 +946,7 @@ class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
                   SizedBox(height: context.appSpacing.sm),
               itemBuilder: (context, index) {
                 final candidate = state.sortedItems[index];
-                return _InlineMagnetCard(candidate: candidate);
+                return _InlineMagnetCard(candidate: candidate, movieNumber: widget.movieNumber);
               },
             ),
           ),
@@ -953,7 +956,7 @@ class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
 
   Widget _buildSkeleton(BuildContext ctx) {
     return SizedBox(
-      height: 180,
+      height: 280,
       child: ListView.separated(
         itemCount: 3,
         separatorBuilder: (_, __) =>
@@ -970,13 +973,49 @@ class _InlineMagnetSectionState extends ConsumerState<_InlineMagnetSection> {
   }
 }
 
-class _InlineMagnetCard extends StatelessWidget {
-  const _InlineMagnetCard({required this.candidate});
-  final dynamic candidate; // DownloadCandidateDto
+class _InlineMagnetCard extends ConsumerStatefulWidget {
+  const _InlineMagnetCard({required this.candidate, required this.movieNumber});
+  final DownloadCandidateDto candidate;
+  final String movieNumber;
+
+  @override
+  ConsumerState<_InlineMagnetCard> createState() => _InlineMagnetCardState();
+}
+
+class _InlineMagnetCardState extends ConsumerState<_InlineMagnetCard> {
+  int? _selectedClientId;
+  bool _isSubmitting = false;
+  bool _submitted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final first = widget.candidate.selectableDownloadClients.firstOrNull;
+    _selectedClientId = first?.id;
+  }
+
+  void _handleSubmit() async {
+    if (_selectedClientId == null || !widget.candidate.hasDownloadSource) return;
+    setState(() => _isSubmitting = true);
+    try {
+      final controller = ref.read(movieDetailMagnetProvider(widget.movieNumber).notifier);
+      await controller.submitCandidate(widget.candidate, clientId: _selectedClientId!);
+      if (mounted) {
+        final name = widget.candidate.selectableDownloadClients
+            .where((c) => c.id == _selectedClientId).firstOrNull?.name ?? '下载器';
+        showToast('已提交到 $name');
+        setState(() { _isSubmitting = false; _submitted = true; });
+      }
+    } catch (e) {
+      if (mounted) { showToast('提交失败'); setState(() => _isSubmitting = false); }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final magnetUrl = candidate.magnetUrl ?? '';
+    final magnetUrl = widget.candidate.magnetUrl ?? '';
+    final clients = widget.candidate.selectableDownloadClients;
+
     return Container(
       padding: EdgeInsets.all(context.appSpacing.sm),
       decoration: BoxDecoration(
@@ -984,52 +1023,90 @@ class _InlineMagnetCard extends StatelessWidget {
         borderRadius: context.appRadius.smBorder,
         border: Border.all(color: context.appColors.borderSubtle),
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  candidate.title ?? '',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: resolveAppTextStyle(context, size: AppTextSize.s12,
-                      weight: AppTextWeight.medium),
-                ),
-                SizedBox(height: context.appSpacing.xs),
-                Wrap(
-                  spacing: context.appSpacing.sm,
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      '做种: ${candidate.seeders}',
-                      style: resolveAppTextStyle(context,
-                          size: AppTextSize.s10,
-                          tone: AppTextTone.muted),
+                      widget.candidate.title ?? '',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: resolveAppTextStyle(context, size: AppTextSize.s12,
+                          weight: AppTextWeight.medium),
                     ),
-                    Text(
-                      formatFileSize(candidate.sizeBytes),
-                      style: resolveAppTextStyle(context,
-                          size: AppTextSize.s10,
-                          tone: AppTextTone.muted),
+                    SizedBox(height: context.appSpacing.xs),
+                    Wrap(
+                      spacing: context.appSpacing.sm,
+                      children: [
+                        Text(
+                          '做种: ${widget.candidate.seeders}',
+                          style: resolveAppTextStyle(context,
+                              size: AppTextSize.s10,
+                              tone: AppTextTone.muted),
+                        ),
+                        Text(
+                          formatFileSize(widget.candidate.sizeBytes),
+                          style: resolveAppTextStyle(context,
+                              size: AppTextSize.s10,
+                              tone: AppTextTone.muted),
+                        ),
+                      ],
                     ),
                   ],
                 ),
-              ],
-            ),
+              ),
+              if (magnetUrl.isNotEmpty)
+                AppIconButton(
+                  key: const Key('inline-magnet-copy'),
+                  tooltip: '复制磁力链接',
+                  size: AppIconButtonSize.mini,
+                  onPressed: () async {
+                    final copied = await copyTextToClipboard(magnetUrl);
+                    if (context.mounted) {
+                      showToast(copied ? '磁力链接已复制' : '复制失败');
+                    }
+                  },
+                  icon: const Icon(Icons.copy_rounded, size: 16),
+                ),
+            ],
           ),
-          if (magnetUrl.isNotEmpty)
-            AppIconButton(
-              key: const Key('inline-magnet-copy'),
-              tooltip: '复制磁力链接',
-              size: AppIconButtonSize.mini,
-              onPressed: () async {
-                final copied = await copyTextToClipboard(magnetUrl);
-                if (context.mounted) {
-                  showToast(copied ? '磁力链接已复制' : '复制失败');
-                }
-              },
-              icon: const Icon(Icons.copy_rounded, size: 16),
+          SizedBox(height: context.appSpacing.sm),
+          // Download row: client selector + submit button
+          if (clients.isNotEmpty)
+            SizedBox(
+              height: 30,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: AppSelectField<int>(
+                      value: _selectedClientId,
+                      size: AppSelectFieldSize.compact,
+                      items: clients.map((c) => DropdownMenuItem<int>(
+                        value: c.id,
+                        child: Text(c.name, style: const TextStyle(fontSize: 12)),
+                      )).toList(),
+                      onChanged: (v) => setState(() => _selectedClientId = v),
+                    ),
+                  ),
+                  SizedBox(width: context.appSpacing.xs),
+                  AppButton(
+                    key: const Key('inline-magnet-submit'),
+                    size: AppButtonSize.xSmall,
+                    label: _submitted
+                        ? '已提交'
+                        : widget.candidate.hasDownloadSource ? '提交下载' : '无资源',
+                    variant: _submitted ? AppButtonVariant.ghost : AppButtonVariant.primary,
+                    isLoading: _isSubmitting,
+                    onPressed: (_submitted || !widget.candidate.hasDownloadSource)
+                        ? null : _handleSubmit,
+                  ),
+                ],
+              ),
             ),
         ],
       ),
@@ -1082,7 +1159,7 @@ class _InlineThumbnailSection extends ConsumerWidget {
         SizedBox(height: context.appSpacing.md),
         if (state.isLoading && state.thumbnails.isEmpty)
           Container(
-            height: 200,
+            height: 280,
             decoration: BoxDecoration(
               color: context.appColors.surfaceMuted,
               borderRadius: context.appRadius.mdBorder,
@@ -1098,7 +1175,7 @@ class _InlineThumbnailSection extends ConsumerWidget {
           const Center(child: AppEmptyState(message: '暂无缩略图'))
         else
           SizedBox(
-            height: 200,
+            height: 280,
             child: LayoutBuilder(
               builder: (context, constraints) {
                 final columns = state.columns ?? 3;


### PR DESCRIPTION
## Summary

将影片详情页的评论、磁力搜索、缩略图三个模块以 **上下并排** 展示在主页面。

同时在磁力卡片标题左侧增加 **Indexer 来源标签**（如 [JavDB]）。

## Trigger Android Release

After merging, please run  on the **main branch** to trigger .

## Changes

- : 新增评论/磁力/缩略图三个纵向排列的 section widget
- : 标题左侧新增 indexer badge

## Preview

Web: http://192.168.66.35:38080 (已部署)

---

cc @tinypinglite